### PR TITLE
Deploy the driving safety incident pipeline #27

### DIFF
--- a/kivakit-filesystems/s3fs/src/main/java/com/telenav/kivakit/filesystems/s3fs/S3Output.java
+++ b/kivakit-filesystems/s3fs/src/main/java/com/telenav/kivakit/filesystems/s3fs/S3Output.java
@@ -60,7 +60,7 @@ public class S3Output extends OutputStream
     {
         this.object = object;
         cacheFile = cacheFile(object.path());
-        outputStream = cacheFile.openForWriting();
+        outputStream = cacheFile.onOpenForWriting();
     }
 
     /** Close this stream and release the lease */


### PR DESCRIPTION
Some bugs found in S3 file system implementation when implementing driving safety incident pipeline, like below:
1. too many S3 client connection created: one for each S3Folder or S3File instance
2. some S3Folder methods (like files, exists) don't work
3. it uses a metadata file to check if a S3 folder exist, which is too specific and doesn't work with the S3 objects created by the external tools (instead of kivakit S3 API). Removed this logic
4. add the S3 endpoint support so we can test it with AWS local stack


