### PR TITLE
Allow local build without requiring gpg keys

### DIFF
--- a/kivakit-filesystems/github/pom.xml
+++ b/kivakit-filesystems/github/pom.xml
@@ -35,6 +35,12 @@
             <artifactId>github-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>kivakit-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/kivakit-filesystems/java/pom.xml
+++ b/kivakit-filesystems/java/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>kivakit-component</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>kivakit-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/kivakit-filesystems/s3fs/pom.xml
+++ b/kivakit-filesystems/s3fs/pom.xml
@@ -24,7 +24,7 @@
         <!-- KivaKit -->
 
         <dependency>
-            <groupId>com.telenav.kivakit</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>kivakit-settings</artifactId>
         </dependency>
 
@@ -35,6 +35,16 @@
             <artifactId>s3</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>kivakit-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.telenav.kivakit</groupId>
+            <artifactId>kivakit-test-internal</artifactId>
+            <scope>test</scope>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/kivakit-filesystems/s3fs/src/main/java/module-info.java
+++ b/kivakit-filesystems/s3fs/src/main/java/module-info.java
@@ -12,7 +12,7 @@ open module kivakit.filesystems.s3fs
     requires software.amazon.awssdk.services.s3;
     requires software.amazon.awssdk.core;
     requires software.amazon.awssdk.regions;
-
+    
     // Module exports
     exports com.telenav.kivakit.filesystems.s3fs;
     exports com.telenav.kivakit.filesystems.s3fs.lexakai;

--- a/kivakit-filesystems/s3fs/src/test/java/com/telenav/kivakit/filesystems/s3fs/S3FileSystemServiceTest.java
+++ b/kivakit-filesystems/s3fs/src/test/java/com/telenav/kivakit/filesystems/s3fs/S3FileSystemServiceTest.java
@@ -19,7 +19,7 @@
 package com.telenav.kivakit.filesystems.s3fs;
 
 import com.telenav.kivakit.core.progress.ProgressReporter;
-import com.telenav.kivakit.core.test.SlowTest;
+import com.telenav.kivakit.core.test.support.SlowTest;
 import com.telenav.kivakit.test.UnitTest;
 import com.telenav.kivakit.resource.FileName;
 import org.junit.Before;

--- a/kivakit-filesystems/s3fs/src/test/java/com/telenav/kivakit/filesystems/s3fs/S3FileTest.java
+++ b/kivakit-filesystems/s3fs/src/test/java/com/telenav/kivakit/filesystems/s3fs/S3FileTest.java
@@ -18,7 +18,7 @@
 
 package com.telenav.kivakit.filesystems.s3fs;
 
-import com.telenav.kivakit.core.test.SlowTest;
+import com.telenav.kivakit.core.test.support.SlowTest;
 import com.telenav.kivakit.test.UnitTest;
 import org.junit.Before;
 import org.junit.Test;

--- a/kivakit-filesystems/s3fs/src/test/java/com/telenav/kivakit/filesystems/s3fs/S3FolderTest.java
+++ b/kivakit-filesystems/s3fs/src/test/java/com/telenav/kivakit/filesystems/s3fs/S3FolderTest.java
@@ -18,7 +18,7 @@
 
 package com.telenav.kivakit.filesystems.s3fs;
 
-import com.telenav.kivakit.core.test.SlowTest;
+import com.telenav.kivakit.core.test.support.SlowTest;
 import com.telenav.kivakit.test.UnitTest;
 import com.telenav.kivakit.filesystem.Folder;
 import com.telenav.kivakit.filesystem.spi.FolderService;

--- a/kivakit-merged/pom.xml
+++ b/kivakit-merged/pom.xml
@@ -105,6 +105,99 @@
 
     </issueManagement>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <!-- Source JAR -->
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-source-jar</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Javadoc JAR -->
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <configuration>
+                            <show>protected</show>
+                            <source>11</source>
+                            <sourcepath>src/main/java</sourcepath>
+                            <failOnError>false</failOnError>
+                            <detectJavaApiLink>false</detectJavaApiLink>
+                            <doclint>none</doclint>
+                            <nohelp>true</nohelp>
+                            <additionalOptions>-notimestamp --show-module-contents all --show-packages all --show-types private</additionalOptions>
+                            <destDir>target/attached-javadocs</destDir>
+                            <sourceFileIncludes>
+                                <sourceFileInclude>**/*.java</sourceFileInclude>
+                            </sourceFileIncludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadoc-jar</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Sign Artifacts -->
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+
+                    <!-- OSSRH -->
+
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>${maven-nexus-staging-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
 
         <plugins>
@@ -151,93 +244,7 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
-
-            <!-- Source JAR -->
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>${maven-source-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>attach-source-jar</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- Javadoc JAR -->
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
-                <configuration>
-                    <show>protected</show>
-                    <source>11</source>
-                    <sourcepath>src/main/java</sourcepath>
-                    <failOnError>false</failOnError>
-                    <detectJavaApiLink>false</detectJavaApiLink>
-                    <doclint>none</doclint>
-                    <nohelp>true</nohelp>
-                    <additionalOptions>-notimestamp --show-module-contents all --show-packages all --show-types private</additionalOptions>
-                    <destDir>target/attached-javadocs</destDir>
-                    <sourceFileIncludes>
-                        <sourceFileInclude>**/*.java</sourceFileInclude>
-                    </sourceFileIncludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadoc-jar</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- Sign Artifacts -->
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>${maven-gpg-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <configuration>
-                            <gpgArguments>
-                                <arg>--pinentry-mode</arg>
-                                <arg>loopback</arg>
-                            </gpgArguments>
-                        </configuration>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-
-            <!-- OSSRH -->
-
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${maven-nexus-staging-plugin.version}</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-
         </plugins>
-
     </build>
 
     <modules>

--- a/kivakit-microservice/pom.xml
+++ b/kivakit-microservice/pom.xml
@@ -127,6 +127,27 @@
 
     <profiles>
         <profile>
+            <id>protoc-apple-silicon</id>
+            <!-- There currently is no Apple silicon build of protoc
+                 available from Maven Central, but an M1 mac will run
+                 x86_64 binaries.
+                 
+                 While forcing the maven-os-plugin to misdetect the
+                 platform is awful, it _is_ slightly less awful than
+                 putting this in `~/.m2/settings.xml` for all maven
+                 builds system-wide, or not being able to build at all. -->
+            <properties>
+                <os.detected.classifier>osx-x86_64</os.detected.classifier>                
+            </properties>
+            <activation>
+                <os>
+                    <name>mac os x</name>
+                    <arch>aarch64</arch>
+                    <family>mac</family>
+                </os>
+            </activation>
+        </profile>        
+        <profile>
             <id>protoc-docker</id>
             <activation>
                 <property><name>docker</name></property>

--- a/kivakit-settings-stores/zookeeper/pom.xml
+++ b/kivakit-settings-stores/zookeeper/pom.xml
@@ -71,7 +71,11 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.telenav.kivakit</groupId>
+            <artifactId>kivakit-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/kivakit-web/jetty/pom.xml
+++ b/kivakit-web/jetty/pom.xml
@@ -49,7 +49,13 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.telenav.kivakit</groupId>
+            <artifactId>kivakit-test</artifactId>
+            <type>jar</type>
+            <!-- Move WebUnitTest to a separate package and uncomment: -->
+            <!--<scope>test</scope>-->
+        </dependency>
     </dependencies>
 
 </project>

--- a/kivakit-web/jetty/src/main/java/com/telenav/kivakit/web/jetty/WebUnitTest.java
+++ b/kivakit-web/jetty/src/main/java/com/telenav/kivakit/web/jetty/WebUnitTest.java
@@ -19,7 +19,7 @@
 package com.telenav.kivakit.web.jetty;
 
 import com.telenav.kivakit.core.messaging.messages.status.Problem;
-import com.telenav.kivakit.core.test.CoreUnitTest;
+import com.telenav.kivakit.core.test.support.CoreUnitTest;
 import com.telenav.kivakit.filesystem.FilePath;
 import com.telenav.kivakit.test.UnitTest;
 import com.telenav.lexakai.annotations.LexakaiJavadoc;

--- a/kivakit-web/jetty/src/main/java/module-info.java
+++ b/kivakit-web/jetty/src/main/java/module-info.java
@@ -9,6 +9,9 @@ open module kivakit.web.jetty
     requires org.eclipse.jetty.util;
     requires org.eclipse.jetty.webapp;
     requires transitive javax.servlet.api;
+    requires transitive kivakit.test;
+    requires transitive kivakit.test.internal;
+    requires kivakit.network.http;
 
     // Module exports
     exports com.telenav.kivakit.web.jetty;

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <module>kivakit-web</module>
         <module>kivakit-filesystems</module>
         <module>kivakit-metrics</module>
+        <module>kivakit-merged</module>
         <module>kivakit-microservice</module>
 
     </modules>


### PR DESCRIPTION
Move the signing and ossrh plugin configuration into a `release` profile that should be set with `--activeProfiles` when releasing, so things are locally buildable without setting up gpg or modifying ~/.m2/settings.xml