### PR TITLE
"'Topologically sort modules to potentially work around issues with broken parallel builds'"

### DIFF
--- a/kivakit-filesystems/pom.xml
+++ b/kivakit-filesystems/pom.xml
@@ -28,8 +28,8 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>s3fs</module>
         <module>github</module>
+        <module>s3fs</module>
         <module>java</module>
     </modules>
 

--- a/kivakit-web/pom.xml
+++ b/kivakit-web/pom.xml
@@ -28,9 +28,9 @@
 
     <modules>
         <module>jetty</module>
-        <module>wicket</module>
         <module>jersey</module>
         <module>swagger</module>
+        <module>wicket</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.telenav</groupId>
         <artifactId>telenav-superpom-project-family</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.3</version>
         <relativePath/>
     </parent>
     

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,12 @@
     
     <modules>
         
-        <module>kivakit-settings-stores</module>
-        <module>kivakit-logs</module>
-        <module>kivakit-web</module>
         <module>kivakit-filesystems</module>
+        <module>kivakit-web</module>
         <module>kivakit-metrics</module>
+        <module>kivakit-settings-stores</module>
         <module>kivakit-microservice</module>
+        <module>kivakit-logs</module>
         
     </modules>
     


### PR DESCRIPTION
"'Topologically sort modules to potentially work around issues with broken parallel builds'



Related Pull Requests
---------------------

  * https://github.com/Telenav/kivakit/pull/138
  * https://github.com/Telenav/kivakit-examples/pull/19


Creating Pull Requests In
-------------------------

  * kivakit topo-sort-modules -> develop
  * kivakit-examples topo-sort-modules -> develop
  * kivakit-extensions topo-sort-modules -> develop
  * kivakit-stuff topo-sort-modules -> develop
  * mesakit topo-sort-modules -> develop
  * mesakit-examples topo-sort-modules -> develop
  * mesakit-extensions topo-sort-modules -> develop
  * telenav-superpom topo-sort-modules -> develop
  * jonstuff topo-sort-modules -> develop


Metadata
--------

  * Invoked on com.telenav:telenav-build:2.0.2
  * SearchNonce: rNoMFcQ5V1-rgwrbn

##### Provenance

Generated by cactus: *cactus-maven-plugin* version _1.5.24_.

  * Mojo:		GitPullRequestMojo
  * Generation-Time:	2022-08-20T09:50:24Z
  * Plugin-Build:	tungsten bobblehead
  * Plugin-Date:	2022.08.20
  * Plugin-Commit:	2586695b880771254e2daf63f2f5f8a5cca1c96b
  * Plugin-Repo-Clean:	false
"