### PR TITLE
"#141 - Invalid response JSON when response is null"

### DIFF
--- a/kivakit-microservice/src/main/java/com/telenav/kivakit/microservice/internal/protocols/rest/plugins/jetty/cycle/JettyRestResponse.java
+++ b/kivakit-microservice/src/main/java/com/telenav/kivakit/microservice/internal/protocols/rest/plugins/jetty/cycle/JettyRestResponse.java
@@ -198,7 +198,11 @@ public final class JettyRestResponse extends BaseComponent
 
                     case "always-okay":
                         writeResponse("{");
-                        writeResponse(stripBrackets(toJson(response)) + ",");
+                        var payload = stripBrackets(toJson(response));
+                        if (!payload.isEmpty())
+                        {
+                            writeResponse(payload + ",");
+                        }
                         writeResponse(stripBrackets(toJson(errors)));
                         writeResponse("}");
                         httpStatus(HttpStatus.OK);


### PR DESCRIPTION
"#141 - Invalid response JSON when response is null

Fixes string concatenation when there is no payload


Creating Pull Requests In
-------------------------

  * cactus bugfix/invalid-json-141 -> develop
  * kivakit bugfix/invalid-json-141 -> develop
  * kivakit-examples bugfix/invalid-json-141 -> develop
  * kivakit-extensions bugfix/invalid-json-141 -> develop
  * kivakit-stuff bugfix/invalid-json-141 -> develop
  * lexakai bugfix/invalid-json-141 -> develop
  * lexakai-annotations bugfix/invalid-json-141 -> develop
  * mesakit bugfix/invalid-json-141 -> develop
  * mesakit-examples bugfix/invalid-json-141 -> develop
  * mesakit-extensions bugfix/invalid-json-141 -> develop
  * safety-service-build bugfix/invalid-json-141 -> develop


Metadata
--------

  * Invoked on com.telenav.scout.safetyservice:safety-service-uber-bom:1.1.1-SNAPSHOT
  * SearchNonce: FcleIP2jQC-rhl7p3

##### Provenance

Generated by cactus: *cactus-git* version _1.5.27_.

  * Mojo:		GitPullRequestMojo
  * Generation-Time:	2022-09-02T14:46:34Z
  * Plugin-Build:	tungsten rocket
  * Plugin-Date:	2022.09.01
  * Plugin-Commit:	afbfc5820e487ecff0edee99a93fa29bbf073481
  * Plugin-Repo-Clean:	true
"